### PR TITLE
feat: add mode and pill button color props to display the chat button

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { Component, Fragment } from "react";
 import ReactDOM from "react-dom";
 import Cui from "../src/react-cui";
 
@@ -19,28 +19,40 @@ class App extends Component {
   }
   render() {
     return (
-      <div>
-        <p>Let's add avatar and theme</p>
-        <Cui
-          uid="d6wXaD"
-          theme="blue"
-          avatar="https://i.imgur.com/6jr3M0j.png"
-          height="400"
-          mode="pill"
-        />
-        {this.state.show && (
+      <Fragment>
+        <section>
+          <div>
+            <p>Let's add avatar and theme</p>
+            <Cui
+              uid="d6wXaD"
+              theme="blue"
+              avatar="https://i.imgur.com/6jr3M0j.png"
+              height="400"
+            />
+            {this.state.show && (
+              <Cui
+                uid="Sb1WbK"
+                theme="red"
+                avatar="https://i.imgur.com/6jr3M0j.png"
+                height="400"
+              />
+            )}
+            <span onClick={this.handleOnClick}>
+              Click to {this.state.show ? "hide" : "show"}
+            </span>
+          </div>
+        </section>
+        <section>
           <Cui
-            uid="Sb1WbK"
-            theme="red"
+            uid="d6wXaD"
+            theme="blue"
             avatar="https://i.imgur.com/6jr3M0j.png"
             height="400"
             mode="pill"
+            pillButtonColor="blue"
           />
-        )}
-        <span onClick={this.handleOnClick}>
-          Click to {this.state.show ? "hide" : "show"}
-        </span>
-      </div>
+        </section>
+      </Fragment>
     );
   }
 }

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,33 +1,48 @@
-import React, { Component } from 'react'
-import ReactDOM from 'react-dom'
-import Cui from '../src/ReactCui'
+import React, { Component } from "react";
+import ReactDOM from "react-dom";
+import Cui from "../src/react-cui";
 
 class App extends Component {
-
   constructor() {
-    super()
+    super();
     this.state = {
       show: false
-    }
+    };
 
-    this.handleOnClick = this.handleOnClick.bind(this)
+    this.handleOnClick = this.handleOnClick.bind(this);
   }
 
   handleOnClick() {
     this.setState(prevState => ({
       show: !prevState.show
-    }))
+    }));
   }
   render() {
-    return <div>
-      <p>Let's add avatar and theme</p>
-      <Cui uid="d6wXaD" theme="blue" avatar="https://i.imgur.com/6jr3M0j.png" height="400" />
-      {this.state.show &&
-        <Cui uid="Sb1WbK" theme="red" avatar="https://i.imgur.com/6jr3M0j.png" height="400" />}
-      <span onClick={this.handleOnClick}>Click to {this.state.show ? 'hide' : 'show'}</span>
-    </div>
+    return (
+      <div>
+        <p>Let's add avatar and theme</p>
+        <Cui
+          uid="d6wXaD"
+          theme="blue"
+          avatar="https://i.imgur.com/6jr3M0j.png"
+          height="400"
+          mode="pill"
+        />
+        {this.state.show && (
+          <Cui
+            uid="Sb1WbK"
+            theme="red"
+            avatar="https://i.imgur.com/6jr3M0j.png"
+            height="400"
+            mode="pill"
+          />
+        )}
+        <span onClick={this.handleOnClick}>
+          Click to {this.state.show ? "hide" : "show"}
+        </span>
+      </div>
+    );
   }
 }
 
-
-ReactDOM.render(<App />, document.getElementById('app'))
+ReactDOM.render(<App />, document.getElementById("app"));

--- a/src/react-cui.js
+++ b/src/react-cui.js
@@ -23,7 +23,7 @@ class Cui extends Component {
   }
 
   render () {
-    const { uid, height, avatar, theme, mode } = this.props
+    const { uid, height, avatar, theme, mode, pillButtonColor } = this.props
     return (
       <Fragment>
         {uid ? (
@@ -35,6 +35,7 @@ class Cui extends Component {
             data-cui-avatar={avatar}
             data-cui-theme={theme}
             data-cui-mode={mode}
+            data-cui-pill-button-color={pillButtonColor}
             ref={this.ref}
           />
         ) : null}
@@ -48,7 +49,8 @@ Cui.propTypes = {
   height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   avatar: PropTypes.string,
   theme: PropTypes.string,
-  mode: PropTypes.string
+  mode: PropTypes.string,
+  pillButtonColor: PropTypes.string
 }
 
 export default Cui

--- a/src/react-cui.js
+++ b/src/react-cui.js
@@ -23,7 +23,7 @@ class Cui extends Component {
   }
 
   render () {
-    const { uid, height, avatar, theme } = this.props
+    const { uid, height, avatar, theme, mode } = this.props
     return (
       <Fragment>
         {uid ? (
@@ -34,6 +34,7 @@ class Cui extends Component {
             data-cui-height={height}
             data-cui-avatar={avatar}
             data-cui-theme={theme}
+            data-cui-mode={mode}
             ref={this.ref}
           />
         ) : null}
@@ -46,7 +47,8 @@ Cui.propTypes = {
   uid: PropTypes.string.isRequired,
   height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   avatar: PropTypes.string,
-  theme: PropTypes.string
+  theme: PropTypes.string,
+  mode: PropTypes.string
 }
 
 export default Cui

--- a/src/react-cui.test.js
+++ b/src/react-cui.test.js
@@ -31,14 +31,22 @@ describe('<Cui />', () => {
     const height = 500
     const avatar = 'https://avatar.com/profile.jpg'
     const theme = '#333'
+    const mode = 'pill'
     const Component = mount(
-      <Cui uid={uid} height={height} avatar={avatar} theme={theme} />
+      <Cui
+        uid={uid}
+        height={height}
+        avatar={avatar}
+        theme={theme}
+        mode={mode}
+      />
     )
     const ComponentDOM = Component.render()
 
     expect(ComponentDOM.attr('data-cui-height')).toBe(height.toString())
     expect(ComponentDOM.attr('data-cui-avatar')).toBe(avatar)
     expect(ComponentDOM.attr('data-cui-theme')).toBe(theme)
+    expect(ComponentDOM.attr('data-cui-mode')).toBe(mode)
   })
 
   test('Component should have the className `cui-embed` so the scripts loads the CUI inside', () => {

--- a/src/react-cui.test.js
+++ b/src/react-cui.test.js
@@ -32,6 +32,7 @@ describe('<Cui />', () => {
     const avatar = 'https://avatar.com/profile.jpg'
     const theme = '#333'
     const mode = 'pill'
+    const pillButtonColor = '#333'
     const Component = mount(
       <Cui
         uid={uid}
@@ -39,6 +40,7 @@ describe('<Cui />', () => {
         avatar={avatar}
         theme={theme}
         mode={mode}
+        pillButtonColor={pillButtonColor}
       />
     )
     const ComponentDOM = Component.render()
@@ -47,6 +49,9 @@ describe('<Cui />', () => {
     expect(ComponentDOM.attr('data-cui-avatar')).toBe(avatar)
     expect(ComponentDOM.attr('data-cui-theme')).toBe(theme)
     expect(ComponentDOM.attr('data-cui-mode')).toBe(mode)
+    expect(ComponentDOM.attr('data-cui-pill-button-color')).toBe(
+      pillButtonColor
+    )
   })
 
   test('Component should have the className `cui-embed` so the scripts loads the CUI inside', () => {


### PR DESCRIPTION
First of all, thanks for working on `react-cui`!!! 🙂 I was trying it out and realised that it was missing the `data-cui-mode` and `data-cui-pill-button-color` attributes that allow conversations UI to be hidden behind a chat button, so I worked on adding it.

I made a small change to allow users to pass a prop `mode` and `pillButtonColor` to the `Cui` component if they decide to use the chat window that way.

I also updated the tests and fixed a small issue in the demo file.

It should look that way now if the user passes `pill` as the `mode` prop:

<img width="452" alt="Screenshot 2020-03-24 at 22 44 29" src="https://user-images.githubusercontent.com/5985247/77480008-2b70a480-6e21-11ea-9d18-5c391e4e1656.png">

Hope it helps! 